### PR TITLE
[TASK] Deployment of Redis Commander as a UI Component

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -209,8 +209,11 @@ module "valkey" {
   // Cluster Secret Store Details
   cluster_secret_store_name = module.openbao.cluster_secret_store_name
 
-  // Certificate details for TLS Authentication
+  // Certificates Details
   cluster_issuer_name = module.cluster-issuer.cluster-issuer-name
+  cloudflare_token    = var.cloudflare_token
+  cloudflare_email    = var.cloudflare_email
+  domain              = var.domain
 
   // Granting required namespaces access to the Valkey
   access_namespaces = "cloud"

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -10,6 +10,7 @@ output "deployment_summary" {
   Garage S3 Object Storage Platform:           https://storage.${var.domain}
   PostgreSQL SQL Database Administration:      https://sql.${var.domain}
   FerretDB NoSQL Database Administration:      https://nosql.${var.domain}
+  Valkey In-Memory Database Administration:    https://memory.${var.domain}
   Keycloak Identity Platform:                  https://auth.${var.domain}
   --------------------------------------------------------------------------------------------
 

--- a/modules/valkey/README.md
+++ b/modules/valkey/README.md
@@ -17,20 +17,34 @@ Required Modules to deploy Valkey In Memory Database:
 
 | Name | Type |
 |------|------|
+| [kubernetes_config_map.ui_nginx_conf](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map.valkey_conf](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_deployment.valkey_ui](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment) | resource |
+| [kubernetes_ingress_v1.ui_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1) | resource |
 | [kubernetes_manifest.certificate_authority](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.ingress_certificate](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.internal_certificate](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.issuer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.middleware_buffering](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.middleware_rewrite](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.password_generator](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.public_issuer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.push_internal_certificate](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.push_ui_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.push_valkey_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.transport](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.ui_credentials_sync](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_manifest.ui_internal_certificate](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.valkey_credentials_sync](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace.namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_network_policy.valkey_network_access_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_pod_disruption_budget_v1.valkey_pdb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod_disruption_budget_v1) | resource |
+| [kubernetes_secret.cloudflare_token](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.redis_commander_configuration](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_service.headless_service](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
 | [kubernetes_service.primary_service](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
 | [kubernetes_service.replica_service](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
+| [kubernetes_service.ui_service](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
 | [kubernetes_stateful_set.valkey_cluster](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/stateful_set) | resource |
 
 ## Inputs
@@ -38,12 +52,19 @@ Required Modules to deploy Valkey In Memory Database:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_namespaces"></a> [access\_namespaces](#input\_access\_namespaces) | Namespaces which require access to Valkey through certificates and network | `string` | n/a | yes |
+| <a name="input_acme_server"></a> [acme\_server](#input\_acme\_server) | URL for the ACME Server to be used, defaults to production URL for LetsEncrypt | `string` | `"https://acme-v02.api.letsencrypt.org/directory"` | no |
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | App name for deploying Valkey Cache Solution | `string` | `"valkey"` | no |
 | <a name="input_certificate_authority_name"></a> [certificate\_authority\_name](#input\_certificate\_authority\_name) | Name of the Certificate Authority to be associated with Valkey Cache Solution | `string` | `"valkey-certificate-authority"` | no |
+| <a name="input_cloudflare_email"></a> [cloudflare\_email](#input\_cloudflare\_email) | Email for generating Ingress Certificates to be associated with OpenBao Secrets Management Solution | `string` | n/a | yes |
+| <a name="input_cloudflare_issuer_name"></a> [cloudflare\_issuer\_name](#input\_cloudflare\_issuer\_name) | Name of the Cloudflare Issuer to be associated with OpenBao Secrets Management Solution | `string` | `"secrets-cloudflare-issuer"` | no |
+| <a name="input_cloudflare_token"></a> [cloudflare\_token](#input\_cloudflare\_token) | Token for generating Ingress Certificates to be associated with OpenBao Secrets Management Solution | `string` | n/a | yes |
 | <a name="input_cluster_issuer_name"></a> [cluster\_issuer\_name](#input\_cluster\_issuer\_name) | Name for the Cluster Issuer to be used to generate internal self signed certificates | `string` | n/a | yes |
 | <a name="input_cluster_secret_store_name"></a> [cluster\_secret\_store\_name](#input\_cluster\_secret\_store\_name) | Name of the cluster secret store to be used for pulling and pushing secrets to OpenBao | `string` | n/a | yes |
 | <a name="input_country_name"></a> [country\_name](#input\_country\_name) | Country name for deploying Valkey Cache Solution | `string` | `"India"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | Domain for which Ingress Certificate is to be generated for | `string` | n/a | yes |
+| <a name="input_host_name"></a> [host\_name](#input\_host\_name) | Host name for which Ingress Certificate is to be generated for | `string` | `"memory"` | no |
 | <a name="input_image"></a> [image](#input\_image) | Docker image to be used for deployment of Valkey | `string` | `"valkey"` | no |
+| <a name="input_ingress_certificate_name"></a> [ingress\_certificate\_name](#input\_ingress\_certificate\_name) | Name of the Ingress Certificate to be associated with Redis Commander | `string` | `"valkey-ui-ingress-certificate"` | no |
 | <a name="input_internal_certificate_name"></a> [internal\_certificate\_name](#input\_internal\_certificate\_name) | Name of the Internal Certificate to be associated with Valkey Cache Solution | `string` | `"valkey-internal-certificate"` | no |
 | <a name="input_issuer_name"></a> [issuer\_name](#input\_issuer\_name) | Name of the Issuer to be associated with Valkey Cache Solution | `string` | `"valkey-certificate-issuer"` | no |
 | <a name="input_metrics_image"></a> [metrics\_image](#input\_metrics\_image) | Docker image to be used for deployment of Valkey Metrics | `string` | `"redis_exporter"` | no |
@@ -52,9 +73,16 @@ Required Modules to deploy Valkey In Memory Database:
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace to be used for deploying Valkey Cache Solution | `string` | `"valkey"` | no |
 | <a name="input_observability_namespace"></a> [observability\_namespace](#input\_observability\_namespace) | Namespace where all components for observability are deployed | `string` | n/a | yes |
 | <a name="input_organization_name"></a> [organization\_name](#input\_organization\_name) | Organization name for deploying Valkey Cache Solution | `string` | `"cloud"` | no |
+| <a name="input_proxy_image"></a> [proxy\_image](#input\_proxy\_image) | Docker image to be used for deployment of Garage NGINX Proxy for TLS | `string` | `"nginx"` | no |
+| <a name="input_proxy_repository"></a> [proxy\_repository](#input\_proxy\_repository) | Repository to be used for deployment of Garage NGINX Proxy for TLS | `string` | `"docker.io/library"` | no |
+| <a name="input_proxy_tag"></a> [proxy\_tag](#input\_proxy\_tag) | Docker tag to be used for deployment of Garage NGINX Proxy for TLS | `string` | `"1.29.0"` | no |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of replicas to run for Valkey Cluster | `number` | `3` | no |
 | <a name="input_repository"></a> [repository](#input\_repository) | Repository to be used for deployment of Valkey | `string` | `"docker.io/valkey"` | no |
 | <a name="input_tag"></a> [tag](#input\_tag) | Docker tag to be used for deployment of Valkey | `string` | `"9.0"` | no |
+| <a name="input_ui_image"></a> [ui\_image](#input\_ui\_image) | Docker image to be used for deployment of Redis Commander | `string` | `"redis-commander"` | no |
+| <a name="input_ui_internal_certificate_name"></a> [ui\_internal\_certificate\_name](#input\_ui\_internal\_certificate\_name) | Name of the Internal Certificate to be associated with Redis Commander | `string` | `"ui-internal-certificate"` | no |
+| <a name="input_ui_repository"></a> [ui\_repository](#input\_ui\_repository) | Repository to be used for deployment of Redis Commander | `string` | `"ghcr.io/joeferner"` | no |
+| <a name="input_ui_tag"></a> [ui\_tag](#input\_ui\_tag) | Docker tag to be used for deployment of Redis Commander | `string` | `"0.9.1"` | no |
 
 ## Outputs
 

--- a/modules/valkey/certificates.tf
+++ b/modules/valkey/certificates.tf
@@ -138,6 +138,55 @@ resource "kubernetes_manifest" "internal_certificate" {
   }
 }
 
+// Internal Certificate for Redis Commannder
+resource "kubernetes_manifest" "ui_internal_certificate" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = var.ui_internal_certificate_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "internal-certificate"
+      }
+    }
+    "spec" = {
+      "dnsNames" = [
+        # For the UI Service
+        "${kubernetes_service.ui_service.metadata[0].name}",
+        "${kubernetes_service.ui_service.metadata[0].name}.${kubernetes_namespace.namespace.metadata[0].name}",
+        "${kubernetes_service.ui_service.metadata[0].name}.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local",
+
+        "127.0.0.1",
+        "localhost",
+      ]
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = [var.app_name]
+      }
+      "commonName" = var.ui_internal_certificate_name
+      "secretName" = var.ui_internal_certificate_name
+      "issuerRef" = {
+        "name" = kubernetes_manifest.issuer.manifest.metadata.name
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
 // Pushing the certificate to OpenBao for distribution
 resource "kubernetes_manifest" "push_internal_certificate" {
   manifest = {
@@ -179,5 +228,127 @@ resource "kubernetes_manifest" "push_internal_certificate" {
       type   = "Ready"
       status = "True"
     }
+  }
+}
+
+// Kubernetes Secret for Cloudflare Tokens
+resource "kubernetes_secret" "cloudflare_token" {
+  metadata {
+    name      = "cloudflare-token"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      "app"       = var.app_name
+      "component" = "secret"
+    }
+  }
+
+  data = {
+    cloudflare-token = var.cloudflare_token
+  }
+
+  type = "Opaque"
+}
+
+// Cloudflare Issuer for Redis Commander Ingress Service
+resource "kubernetes_manifest" "public_issuer" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Issuer"
+    "metadata" = {
+      "name"      = var.cloudflare_issuer_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "cloudflare-issuer"
+      }
+    }
+    "spec" = {
+      "acme" = {
+        "email"  = var.cloudflare_email
+        "server" = var.acme_server
+        "privateKeySecretRef" = {
+          "name" = var.cloudflare_issuer_name
+        }
+        "solvers" = [
+          {
+            "dns01" = {
+              "cloudflare" = {
+                "email" = var.cloudflare_email
+                "apiTokenSecretRef" = {
+                  "name" = "cloudflare-token"
+                  "key"  = "cloudflare-token"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  depends_on = [kubernetes_secret.cloudflare_token]
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+
+// Certificate to be used for Redis Commander Ingress
+resource "kubernetes_manifest" "ingress_certificate" {
+
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind"       = "Certificate"
+    "metadata" = {
+      "name"      = var.ingress_certificate_name
+      "namespace" = kubernetes_namespace.namespace.metadata[0].name
+      "labels" = {
+        "app"       = var.app_name
+        "component" = "ingress-certificate"
+      }
+    }
+    "spec" = {
+      "duration"    = "2160h"
+      "renewBefore" = "360h"
+      "subject" = {
+        "organizations"       = [var.organization_name]
+        "countries"           = [var.country_name]
+        "organizationalUnits" = [var.app_name]
+      }
+      "privateKey" = {
+        "algorithm" = "RSA"
+        "encoding"  = "PKCS1"
+        "size"      = "2048"
+      }
+      "dnsNames"   = ["${var.host_name}.${var.domain}"]
+      "secretName" = var.ingress_certificate_name
+      "issuerRef" = {
+        "name"  = kubernetes_manifest.public_issuer.manifest.metadata.name
+        "kind"  = "Issuer"
+        "group" = "cert-manager.io"
+      }
+    }
+  }
+
+  wait {
+    condition {
+      type   = "Ready"
+      status = "True"
+    }
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }

--- a/modules/valkey/configmap.tf
+++ b/modules/valkey/configmap.tf
@@ -34,3 +34,59 @@ resource "kubernetes_config_map" "valkey_conf" {
     EOF
   }
 }
+
+# NGINX Configuration for SSL-ing requests to the container
+resource "kubernetes_config_map" "ui_nginx_conf" {
+  metadata {
+    name      = "garage-ui-nginx-conf"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+  }
+  data = {
+    "nginx.conf" = <<EOF
+      pid /tmp/nginx.pid;
+      events {}
+      http {
+
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp_path;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+        client_max_body_size 500M;
+
+        server {
+          listen 8443 ssl;
+
+          server_name valkey-ui-service.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local;
+
+          ssl_certificate     /mnt/ssl/tls.crt;
+          ssl_certificate_key /mnt/ssl/tls.key;
+
+          # ssl_session_cache builtin:1000 shared:SSL:10m;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+          ssl_prefer_server_ciphers off;
+          ssl_session_timeout 1d;
+          ssl_session_cache shared:SSL:10m;
+          ssl_session_tickets off;
+
+          location / {
+              proxy_set_header X-Script-Name /;
+              proxy_set_header X-Scheme $scheme;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+              
+              proxy_set_header Host $host;
+
+              proxy_pass http://127.0.0.1:8081;
+              proxy_redirect off;
+
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+          }
+        }
+      }
+    EOF
+  }
+}

--- a/modules/valkey/ingress.tf
+++ b/modules/valkey/ingress.tf
@@ -1,0 +1,56 @@
+// Kubernetes Ingress for Redis Commander
+resource "kubernetes_ingress_v1" "ui_ingress" {
+  metadata {
+    name      = "ui-ingress"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      app       = var.app_name
+      component = "ingress"
+    }
+    
+    // Attaching all middlewares and server transports
+    annotations = {
+      "traefik.ingress.kubernetes.io/router.middlewares" = join(",", [
+        "${kubernetes_namespace.namespace.metadata[0].name}-${kubernetes_manifest.middleware_rewrite.manifest.metadata.name}@kubernetescrd",
+        "${kubernetes_namespace.namespace.metadata[0].name}-${kubernetes_manifest.middleware_buffering.manifest.metadata.name}@kubernetescrd"
+      ])
+      "traefik.ingress.kubernetes.io/service.serverstransport" = "${kubernetes_namespace.namespace.metadata[0].name}-${kubernetes_manifest.transport.manifest.metadata.name}@kubernetescrd"
+      "traefik.ingress.kubernetes.io/router.tls" = "true"
+      "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
+    }
+  }
+
+  spec {
+    ingress_class_name = "traefik"
+    tls {
+      hosts       = ["${var.host_name}.${var.domain}"]
+      secret_name = kubernetes_manifest.ingress_certificate.manifest.spec.secretName
+    }
+    rule {
+      host = "${var.host_name}.${var.domain}"
+      http {
+        path {
+          path = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = kubernetes_service.ui_service.metadata[0].name
+              port {
+                number = 8443
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+depends_on = [
+    kubernetes_manifest.middleware_rewrite,
+    kubernetes_manifest.middleware_buffering,
+    kubernetes_manifest.transport,
+    kubernetes_manifest.ingress_certificate
+  ]  
+
+}

--- a/modules/valkey/middleware.tf
+++ b/modules/valkey/middleware.tf
@@ -1,0 +1,34 @@
+// Middleware 1: The Rewrite logic
+resource "kubernetes_manifest" "middleware_rewrite" {
+  manifest = {
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "Middleware"
+    metadata = {
+      name      = "rewrite"
+      namespace = kubernetes_namespace.namespace.metadata[0].name
+    }
+    spec = {
+      replacePathRegex = {
+        regex       = "^/(.*)$"
+        replacement = "/$1"
+      }
+    }
+  }
+}
+
+// Middleware 2: The Buffering logic
+resource "kubernetes_manifest" "middleware_buffering" {
+  manifest = {
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "Middleware"
+    metadata = {
+      name      = "buffering"
+      namespace = kubernetes_namespace.namespace.metadata[0].name
+    }
+    spec = {
+      buffering = {
+        maxRequestBodyBytes = 524288000
+      }
+    }
+  }
+}

--- a/modules/valkey/networkpolicy.tf
+++ b/modules/valkey/networkpolicy.tf
@@ -58,7 +58,7 @@ resource "kubernetes_network_policy" "valkey_network_access_policy" {
       }
     }
 
-    # Rule 3: Allow OpenTelemetry Collector to scrape Garage metrics
+    # Rule 3: Allow OpenTelemetry Collector to scrape Valkey metrics
     ingress {
       from {
         namespace_selector {
@@ -80,7 +80,25 @@ resource "kubernetes_network_policy" "valkey_network_access_policy" {
       }
     }
 
-    # -------------- INGRESS RULES -------------- #
+    # Rule 4: Allow ingress from Redis Commander pods
+    ingress {
+      from {
+        pod_selector {
+          match_labels = {
+            app       = var.app_name
+            component = "pod"
+            "part-of" = "valkey-ui"
+            "valkey-ui-access" = true
+          }
+        }
+      }
+      ports {
+        protocol = "TCP"
+        port     = 6379
+      }
+    }
+
+    # -------------- EGRESS RULES -------------- #
     # Rule 1: Allow egress to other Valkey pods
     egress {
       to {

--- a/modules/valkey/secrets.tf
+++ b/modules/valkey/secrets.tf
@@ -81,3 +81,91 @@ resource "kubernetes_manifest" "push_valkey_credentials" {
   }
   depends_on = [kubernetes_manifest.valkey_credentials_sync]
 }
+
+// Credentials configuration for Redis Commander
+resource "kubernetes_manifest" "ui_credentials_sync" {
+  manifest = {
+    apiVersion = "external-secrets.io/v1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "ui-credentials"
+      namespace = kubernetes_namespace.namespace.metadata[0].name
+    }
+    spec = {
+      refreshInterval = "0"
+      target = {
+        name = "ui-credentials"
+        template = {
+          data = {
+            HTTP_USER     = "valkey.admin"
+            HTTP_PASSWORD = "{{ .password }}"
+          }
+        }
+      }
+      dataFrom = [{
+        sourceRef = {
+          generatorRef = {
+            apiVersion = "generators.external-secrets.io/v1alpha1"
+            kind       = "Password"
+            name       = kubernetes_manifest.password_generator.object.metadata.name
+          }
+        }
+      }]
+    }
+  }
+}
+
+resource "kubernetes_manifest" "push_ui_credentials" {
+  manifest = {
+    apiVersion = "external-secrets.io/v1alpha1"
+    kind       = "PushSecret"
+    metadata = {
+      name      = "push-${kubernetes_manifest.ui_credentials_sync.object.spec.target.name}"
+      namespace = kubernetes_namespace.namespace.metadata[0].name
+    }
+    spec = {
+      refreshInterval = "1h"
+      deletionPolicy  = "None"
+      secretStoreRefs = [{
+        name = var.cluster_secret_store_name
+        kind = "ClusterSecretStore"
+      }]
+      selector = {
+        secret = {
+          name = kubernetes_manifest.ui_credentials_sync.object.spec.target.name
+        }
+      }
+      data = [
+        {
+          match = {
+            remoteRef = {
+              remoteKey = "${kubernetes_namespace.namespace.metadata[0].name}/credentials/ui/${kubernetes_manifest.ui_credentials_sync.object.spec.target.name}"
+            }
+          }
+        }
+      ]
+    }
+  }
+  depends_on = [kubernetes_manifest.ui_credentials_sync]
+}
+
+resource "kubernetes_secret" "redis_commander_configuration" {
+  metadata {
+    name = "redis-commander-configuration"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      app       = var.app_name
+      component = "secret"
+    }
+  }
+
+  data = {
+    "REDIS_HOST"             = "${kubernetes_service.primary_service.metadata[0].name}.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local"
+    "REDIS_PORT"             = 6379
+    "REDIS_TLS"              = true
+    "REDIS_TLS_CA_CERT_FILE" = "/mnt/certs/ca.crt"
+    "REDIS_TLS_CERT_FILE"    = "/mnt/certs/tls.crt"
+    "REDIS_TLS_KEY_FILE"     = "/mnt/certs/tls.key"
+    "REDIS_TLS_SERVER_NAME"  = "${kubernetes_service.primary_service.metadata[0].name}.${kubernetes_namespace.namespace.metadata[0].name}.svc.cluster.local"
+  }
+}

--- a/modules/valkey/service.tf
+++ b/modules/valkey/service.tf
@@ -76,3 +76,33 @@ resource "kubernetes_service" "replica_service" {
     }
   }
 }
+
+// Service for Exposing Redis Commander
+resource "kubernetes_service" "ui_service" {
+  metadata {
+    name      = "valkey-ui-service"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      app       = var.app_name
+      component = "service"
+    }
+    annotations = {
+      "traefik.ingress.kubernetes.io/service.serversscheme" = "https"
+    }
+  }
+
+  spec {
+    port {
+      port        = 8443
+      target_port = 8443
+      name        = "https"
+    }
+
+    selector = {
+      app       = var.app_name
+      component = "pod"
+      "part-of" = "valkey-ui"
+      "valkey-ui-access" = true
+    }
+  }
+}

--- a/modules/valkey/transport.tf
+++ b/modules/valkey/transport.tf
@@ -1,0 +1,19 @@
+// Server Transport Resource for HTTPS Backend Connections
+resource "kubernetes_manifest" "transport" {
+  manifest = {
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "ServersTransport"
+    metadata = {
+      name      = "transport"
+      namespace = kubernetes_namespace.namespace.metadata[0].name
+    }
+    spec = {
+      insecureSkipVerify = true
+      rootCAs = [
+        {
+          secret = kubernetes_manifest.internal_certificate.manifest.spec.secretName
+        }
+      ]
+    }
+  }
+}

--- a/modules/valkey/valkey_ui.tf
+++ b/modules/valkey/valkey_ui.tf
@@ -1,0 +1,210 @@
+# UI Component for Valkey
+resource "kubernetes_deployment" "valkey_ui" {
+  metadata {
+    name      = "valkey-ui"
+    namespace = kubernetes_namespace.namespace.metadata[0].name
+    labels = {
+      app       = var.app_name
+      component = "deployment"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    // Selectors for the pods
+    // Network policy will also be applied here
+    selector {
+      match_labels = {
+        app       = var.app_name
+        component = "pod"
+        "part-of" = "valkey-ui"
+        "valkey-ui-access" = true
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app       = var.app_name
+          component = "pod"
+          "part-of" = "valkey-ui"
+          "valkey-ui-access" = true
+        }
+      }
+
+      spec {
+
+        // Node Affinity rule to run only on worker nodes
+        affinity {
+          node_affinity {
+            required_during_scheduling_ignored_during_execution {
+              node_selector_term {
+                match_expressions {
+                  key      = "worker"
+                  operator = "Exists"
+                }
+              }
+            }
+          }
+        }
+
+        // Topology Spread to ensure pods are running on seperate nodes
+        topology_spread_constraint {
+          max_skew           = 1
+          topology_key       = "kubernetes.io/hostname"
+          when_unsatisfiable = "DoNotSchedule"
+          label_selector {
+            match_labels = {
+              app       = var.app_name
+              component = "pod"
+              "part-of" = "valkey-ui"
+              "valkey-ui-access" = true
+            }
+          }
+        }
+        
+        container {
+          name  = "valkey-ui"
+          image = "${var.ui_repository}/${var.ui_image}:${var.ui_tag}"
+          
+          # Password to authenticate against Valkey
+          env {
+            name  = "REDIS_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_manifest.valkey_credentials_sync.object.spec.target.name
+                key = "VALKEY_PASSWORD"
+              }
+            }
+          }
+
+          # Full Configuration for the UI Solution
+          env_from {
+            secret_ref {
+              name = kubernetes_secret.redis_commander_configuration.metadata[0].name
+            }
+          }
+
+          # Credentials configuration for Redis Commander          
+          env_from {
+            secret_ref {
+              name = kubernetes_manifest.ui_credentials_sync.object.spec.target.name
+            }
+          }
+          
+          # Mounting the SSL certs for communicating with Valkey in TLS
+          volume_mount {
+            name       = "certificates"
+            mount_path = "/mnt/certs"
+          }
+
+          # Health checks to turn green
+          # when the UI service is up
+          liveness_probe {
+            http_get {
+              path = "/favicon.png"
+              port = 8081
+            }
+            period_seconds = 10
+            success_threshold = 1
+            failure_threshold = 5
+          }
+          
+          readiness_probe {
+            http_get {
+              path = "/favicon.png"
+              port = 8081
+            }
+            period_seconds = 10
+            success_threshold = 1
+            failure_threshold = 5
+          }
+
+          # Use non root credentials to run the containers
+          security_context {
+            run_as_group    = 10000
+            run_as_non_root = true
+            run_as_user     = 10000
+          }
+          
+        }
+
+        container {
+          name  = "proxy"
+          image = "${var.proxy_repository}/${var.proxy_image}:${var.proxy_tag}"
+
+          # HTTPS Mapping for the UI service
+          port {
+            container_port = 8443
+            name           = "https"
+          }
+
+          # Mounting the SSL certs for HTTPS duties
+          volume_mount {
+            name       = "certificates"
+            mount_path = "/mnt/ssl"
+          }
+
+          # NGINX Configuration for HTTPS duties
+          volume_mount {
+            name       = "nginx-config"
+            mount_path = "/etc/nginx"
+          }
+
+          # Liveness and readiness probes to check if the container is up
+          liveness_probe {
+            exec {
+              command = ["curl", "--cacert", "/mnt/ssl/ca.crt", "https://localhost:8443/favicon.png"]
+            }
+            period_seconds        = 30
+          }
+
+          readiness_probe {
+            exec {
+              command = ["curl", "--cacert", "/mnt/ssl/ca.crt", "https://localhost:8443/favicon.png"]
+            }
+            period_seconds        = 30
+          }
+
+          # Use non root credentials to run the containers
+          security_context {
+            run_as_group    = 1000
+            run_as_non_root = true
+            run_as_user     = 1000
+          }
+          
+        }
+        
+        
+        # Mount the certificates for Valkey to communicate TLS with
+        volume {
+          name = "ca-certs"
+          secret {
+            secret_name = kubernetes_manifest.internal_certificate.object.spec.secretName
+          }
+        }
+
+        # Mount the certificates required to perform TLS connections
+        volume {
+          name = "certificates"
+          secret {
+            secret_name = kubernetes_manifest.ui_internal_certificate.object.spec.secretName
+          }
+        }
+
+        # Mount the confiuration for NGINX to perform internal TLS duties
+        volume {
+          name = "nginx-config"
+          config_map {
+            name = kubernetes_config_map.ui_nginx_conf.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_manifest.internal_certificate
+  ]
+}

--- a/modules/valkey/variables.tf
+++ b/modules/valkey/variables.tf
@@ -62,6 +62,54 @@ variable "internal_certificate_name" {
   default     = "valkey-internal-certificate"
 }
 
+variable "ui_internal_certificate_name" {
+  description = "Name of the Internal Certificate to be associated with Redis Commander"
+  type        = string
+  default     = "ui-internal-certificate"
+}
+
+variable "cloudflare_token" {
+  description = "Token for generating Ingress Certificates to be associated with OpenBao Secrets Management Solution"
+  type        = string
+  nullable    = false
+}
+
+variable "cloudflare_email" {
+  description = "Email for generating Ingress Certificates to be associated with OpenBao Secrets Management Solution"
+  type        = string
+  nullable    = false
+}
+
+variable "cloudflare_issuer_name" {
+  description = "Name of the Cloudflare Issuer to be associated with OpenBao Secrets Management Solution"
+  type        = string
+  default     = "secrets-cloudflare-issuer"
+}
+
+variable "acme_server" {
+  description = "URL for the ACME Server to be used, defaults to production URL for LetsEncrypt"
+  type        = string
+  default     = "https://acme-v02.api.letsencrypt.org/directory"
+}
+
+variable "ingress_certificate_name" {
+  description = "Name of the Ingress Certificate to be associated with Redis Commander"
+  type        = string
+  default     = "valkey-ui-ingress-certificate"
+}
+
+variable "host_name" {
+  description = "Host name for which Ingress Certificate is to be generated for"
+  type        = string
+  default     = "memory"
+}
+
+variable "domain" {
+  description = "Domain for which Ingress Certificate is to be generated for"
+  type        = string
+  nullable    = false
+}
+
 # --------------- REPLICATION VARIABLES --------------- #
 variable "access_namespaces" {
   description = "Namespaces which require access to Valkey through certificates and network"
@@ -111,4 +159,41 @@ variable "metrics_tag" {
   description = "Docker tag to be used for deployment of Valkey Metrics"
   type        = string
   default     = "v1.81.0-alpine"
+}
+
+# --------------- REDIS COMMMANDER VARIABLES --------------- #
+variable "ui_repository" {
+  description = "Repository to be used for deployment of Redis Commander"
+  type        = string
+  default     = "ghcr.io/joeferner"
+}
+
+variable "ui_image" {
+  description = "Docker image to be used for deployment of Redis Commander"
+  type        = string
+  default     = "redis-commander"
+}
+
+variable "ui_tag" {
+  description = "Docker tag to be used for deployment of Redis Commander"
+  type        = string
+  default     = "0.9.1"
+}
+
+variable "proxy_repository" {
+  description = "Repository to be used for deployment of Garage NGINX Proxy for TLS"
+  type        = string
+  default     = "docker.io/library"
+}
+
+variable "proxy_image" {
+  description = "Docker image to be used for deployment of Garage NGINX Proxy for TLS"
+  type        = string
+  default     = "nginx"
+}
+
+variable "proxy_tag" {
+  description = "Docker tag to be used for deployment of Garage NGINX Proxy for TLS"
+  type        = string
+  default     = "1.29.0"
 }


### PR DESCRIPTION
# Implemented Changes
 - Automated Deployment of [Redis Commander](https://github.com/joeferner/redis-commander) as a UI Component
 - TLS configured end to end for the same
 - The DNS used for the same is `memory.${{ SUBDOMAIN }}`
 
**Closes: #152**
