### PR TITLE
[TASK] Making the modules extra customizable - FerretDB Module

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -158,6 +158,9 @@ module "ferretdb" {
   // Observability details
   observability_namespace = module.observability.observability_namespace
 
+  // Cluster sizing details
+  cluster_size = "small"
+
   // Required client details to allow access and generate credentials and certificates for
   clients = [
     {
@@ -176,6 +179,12 @@ module "ferretdb" {
   kubernetes_api_ip       = one(flatten(data.kubernetes_endpoints_v1.kubernetes_api_endpoint.subset[*].address[*].ip))
   kubernetes_api_protocol = one(flatten(data.kubernetes_endpoints_v1.kubernetes_api_endpoint.subset[*].port[*].protocol))
   kubernetes_api_port     = one(flatten(data.kubernetes_endpoints_v1.kubernetes_api_endpoint.subset[*].port[*].port))
+
+  // Enabling and disabling features
+  enable_internal_tls_certificates = true
+  enable_ui                        = true
+  enable_pitr_backups              = true
+  enable_observability             = true
 
   // Dependency on Garage Deployment  
   depends_on = [module.garage, module.observability, module.openbao]

--- a/modules/ferretdb/README.md
+++ b/modules/ferretdb/README.md
@@ -4,9 +4,9 @@ OpenTofu Module to deploy [FerretDB](https://www.ferretdb.com/) (MongoDB) Databa
 
 Required Modules to deploy FerretDB Database:
 1. [Helm](../helm)
-2. [Cluster Issuer](../cluster-issuer)
-3. [Garage](../garage)
-4. [Observability](../observability)
+2. [Cluster Issuer](../cluster-issuer) (Optional if setting `enable_internal_tls_certificates` as `false`)
+3. [Garage](../garage) (Optional if setting `enable_pitr_backups` as `false`)
+4. [Observability](../observability) (Optional if setting `enable_observability` as `false`)
 5. [OpenBao](../openbao)
 
 ## Providers
@@ -73,9 +73,13 @@ Required Modules to deploy FerretDB Database:
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the Ferret Database Cluster to be created | `string` | `"ferret-postgresql-cluster"` | no |
 | <a name="input_cluster_postgresql_version"></a> [cluster\_postgresql\_version](#input\_cluster\_postgresql\_version) | Version of Ferret Database to use and deploy | `number` | `17` | no |
 | <a name="input_cluster_secret_store_name"></a> [cluster\_secret\_store\_name](#input\_cluster\_secret\_store\_name) | Name of the cluster secret store to be used for pulling and pushing secrets to OpenBao | `string` | n/a | yes |
-| <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Number of pods to deploy for the Ferret Cluster | `number` | `2` | no |
+| <a name="input_cluster_size"></a> [cluster\_size](#input\_cluster\_size) | Number of pods to deploy for the PostgreSQL Cluster | `string` | `"small"` | no |
 | <a name="input_country_name"></a> [country\_name](#input\_country\_name) | Country name for deploying Ferret Database | `string` | `"India"` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain for which Ingress Certificate is to be generated for | `string` | n/a | yes |
+| <a name="input_enable_internal_tls_certificates"></a> [enable\_internal\_tls\_certificates](#input\_enable\_internal\_tls\_certificates) | Enable or disable deployment of Internal TLS Certificates for the FerretDB Cluster | `bool` | `true` | no |
+| <a name="input_enable_observability"></a> [enable\_observability](#input\_enable\_observability) | Enable or disable observability reporting for the FerretDB Cluster | `bool` | `true` | no |
+| <a name="input_enable_pitr_backups"></a> [enable\_pitr\_backups](#input\_enable\_pitr\_backups) | Enable or disable PITR Backups to the Garage Instance for the FerretDB Cluster | `bool` | `true` | no |
+| <a name="input_enable_ui"></a> [enable\_ui](#input\_enable\_ui) | Enable or disable deployment of PGAdmin for the FerretDB Cluster | `bool` | `true` | no |
 | <a name="input_garage_certificate_authority"></a> [garage\_certificate\_authority](#input\_garage\_certificate\_authority) | Name of the Certificate Authority associated with the Garage Storage Solution | `string` | n/a | yes |
 | <a name="input_garage_configuration"></a> [garage\_configuration](#input\_garage\_configuration) | Garage Configuration for storing PITR Backups | `string` | n/a | yes |
 | <a name="input_garage_namespace"></a> [garage\_namespace](#input\_garage\_namespace) | Namespace for the Garage Deployment for storing PITR Backups | `string` | n/a | yes |

--- a/modules/ferretdb/certificates.tf
+++ b/modules/ferretdb/certificates.tf
@@ -359,6 +359,7 @@ resource "kubernetes_manifest" "mongo_express_internal_certificate" {
 
 // Kubernetes Secret for Cloudflare Tokens
 resource "kubernetes_secret" "cloudflare_token" {
+  count = var.enable_ui ? 1 : 0
   metadata {
     name      = "cloudflare-token"
     namespace = kubernetes_namespace.namespace.metadata[0].name
@@ -377,6 +378,7 @@ resource "kubernetes_secret" "cloudflare_token" {
 
 // Cloudflare Issuer for MongoExpress Ingress Service
 resource "kubernetes_manifest" "public_issuer" {
+  count = var.enable_ui ? 1 : 0
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "Issuer"
@@ -430,6 +432,7 @@ resource "kubernetes_manifest" "public_issuer" {
 
 // Certificate to be used for MongoExpress Ingress
 resource "kubernetes_manifest" "ingress_certificate" {
+  count = var.enable_ui ? 1 : 0
 
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
@@ -458,7 +461,7 @@ resource "kubernetes_manifest" "ingress_certificate" {
       "dnsNames"   = ["${var.host_name}.${var.domain}"]
       "secretName" = var.ingress_certificate_name
       "issuerRef" = {
-        "name"  = kubernetes_manifest.public_issuer.manifest.metadata.name
+        "name"  = kubernetes_manifest.public_issuer[0].manifest.metadata.name
         "kind"  = "Issuer"
         "group" = "cert-manager.io"
       }

--- a/modules/ferretdb/certificates.tf
+++ b/modules/ferretdb/certificates.tf
@@ -1,5 +1,6 @@
 // Fetch Garage Certificate Authority for PITR Backups
 resource "kubernetes_manifest" "garage_certificate_authority_sync" {
+  count = var.enable_pitr_backups ? 1 : 0
   manifest = {
     apiVersion = "external-secrets.io/v1"
     kind       = "ExternalSecret"

--- a/modules/ferretdb/certificates.tf
+++ b/modules/ferretdb/certificates.tf
@@ -45,6 +45,7 @@ resource "kubernetes_manifest" "garage_certificate_authority_sync" {
 # --------------- POSTGRESQL SERVER CERTIFICATES CONFIGURATION --------------- #
 // Certificate Authority to be used with PostgreSQL Server
 resource "kubernetes_manifest" "server_certificate_authority" {
+  count = var.enable_internal_tls_certificates ? 1 : 0
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "Certificate"
@@ -94,6 +95,7 @@ resource "kubernetes_manifest" "server_certificate_authority" {
 
 // Issuer to be used with PostgreSQL Server
 resource "kubernetes_manifest" "server_issuer" {
+  count = var.enable_internal_tls_certificates ? 1 : 0
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "Issuer"
@@ -107,7 +109,7 @@ resource "kubernetes_manifest" "server_issuer" {
     }
     "spec" = {
       "ca" = {
-        "secretName" = kubernetes_manifest.server_certificate_authority.manifest.spec.secretName
+        "secretName" = kubernetes_manifest.server_certificate_authority[0].manifest.spec.secretName
       }
     }
   }
@@ -128,6 +130,7 @@ resource "kubernetes_manifest" "server_issuer" {
 
 // Certificate for PostgreSQL Server
 resource "kubernetes_manifest" "server_certificate" {
+  count = var.enable_internal_tls_certificates ? 1 : 0
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "Certificate"
@@ -159,7 +162,7 @@ resource "kubernetes_manifest" "server_certificate" {
       }
       "secretName" = var.server_certificate_name
       "issuerRef" = {
-        "name" = kubernetes_manifest.server_issuer.manifest.metadata.name
+        "name" = kubernetes_manifest.server_issuer[0].manifest.metadata.name
       }
     }
   }
@@ -182,6 +185,7 @@ resource "kubernetes_manifest" "server_certificate" {
 # --------------- POSTGRESQL CLIENT CERTIFICATES CONFIGURATION --------------- #
 // Certificate Authority to be used with PostgreSQL Client
 resource "kubernetes_manifest" "client_certificate_authority" {
+  count = var.enable_internal_tls_certificates ? 1 : 0
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "Certificate"
@@ -231,6 +235,7 @@ resource "kubernetes_manifest" "client_certificate_authority" {
 
 // Issuer to be used with PostgreSQL Client
 resource "kubernetes_manifest" "client_issuer" {
+  count = var.enable_internal_tls_certificates ? 1 : 0
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "Issuer"
@@ -244,7 +249,7 @@ resource "kubernetes_manifest" "client_issuer" {
     }
     "spec" = {
       "ca" = {
-        "secretName" = kubernetes_manifest.client_certificate_authority.manifest.spec.secretName
+        "secretName" = kubernetes_manifest.client_certificate_authority[0].manifest.spec.secretName
       }
     }
   }
@@ -265,6 +270,7 @@ resource "kubernetes_manifest" "client_issuer" {
 
 // Certificate for Streaming Replica
 resource "kubernetes_manifest" "client_streaming_replica_certificate" {
+  count = var.enable_internal_tls_certificates ? 1 : 0
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "Certificate"
@@ -286,7 +292,7 @@ resource "kubernetes_manifest" "client_streaming_replica_certificate" {
       "commonName" = "streaming_replica"
       "secretName" = var.client_streaming_replica_certificate_name
       "issuerRef" = {
-        "name" = kubernetes_manifest.client_issuer.manifest.metadata.name
+        "name" = kubernetes_manifest.client_issuer[0].manifest.metadata.name
       }
     }
   }
@@ -307,6 +313,7 @@ resource "kubernetes_manifest" "client_streaming_replica_certificate" {
 
 // Internal Certificate for MongoExpress
 resource "kubernetes_manifest" "mongo_express_internal_certificate" {
+  count = var.enable_internal_tls_certificates ? 1 : 0
   manifest = {
     "apiVersion" = "cert-manager.io/v1"
     "kind"       = "Certificate"
@@ -332,7 +339,7 @@ resource "kubernetes_manifest" "mongo_express_internal_certificate" {
       "commonName" = "mongo-express-internal-certificate"
       "secretName" = "mongo-express-internal-certificate"
       "issuerRef" = {
-        "name" = kubernetes_manifest.server_issuer.manifest.metadata.name
+        "name" = kubernetes_manifest.server_issuer[0].manifest.metadata.name
       }
     }
   }

--- a/modules/ferretdb/cluster.tf
+++ b/modules/ferretdb/cluster.tf
@@ -45,7 +45,7 @@ resource "kubernetes_manifest" "cluster" {
       }
       "description"           = "PostgreSQL Cluster for storing relational data"
       "enableSuperuserAccess" = true
-      "instances"             = var.cluster_size
+      "instances"             = local.cnpg_size_lookup[var.cluster_size]
       // Required postgresql configuration for DocumentDB
       "postgresql" = {
         "shared_preload_libraries" = [

--- a/modules/ferretdb/cluster.tf
+++ b/modules/ferretdb/cluster.tf
@@ -16,11 +16,11 @@ resource "kubernetes_manifest" "cluster" {
         "labels" = {
           "garage-access" = true
         }
-        "annotations" = {
+        "annotations" = var.enable_observability ? {
           "prometheus.io/scrape" = "true"
           "prometheus.io/port"   = "9187"
           "prometheus.io/path"   = "/metrics"
-        }
+        } : {}
       }
       "postgresUID" = 999
       "postgresGID" = 999

--- a/modules/ferretdb/cluster.tf
+++ b/modules/ferretdb/cluster.tf
@@ -122,15 +122,15 @@ resource "kubernetes_manifest" "cluster" {
         "clientCASecret"       = kubernetes_manifest.client_certificate_authority[0].manifest.spec.secretName
         "replicationTLSSecret" = kubernetes_manifest.client_streaming_replica_certificate[0].manifest.spec.secretName
       } : null
-      "plugins" = [
+      "plugins" = var.enable_pitr_backups ? [
         {
           "name"          = "barman-cloud.cloudnative-pg.io"
           "isWALArchiver" = true
           "parameters" = {
-            "barmanObjectName" = kubernetes_manifest.barman_object_store.manifest.metadata.name
+            "barmanObjectName" = kubernetes_manifest.barman_object_store[0].manifest.metadata.name
           }
         }
-      ]
+      ] : []
     }
   }
 

--- a/modules/ferretdb/cluster.tf
+++ b/modules/ferretdb/cluster.tf
@@ -116,12 +116,12 @@ resource "kubernetes_manifest" "cluster" {
         }
         "size" = "5Gi"
       }
-      "certificates" = {
-        "serverTLSSecret"      = kubernetes_manifest.server_certificate.manifest.spec.secretName
-        "serverCASecret"       = kubernetes_manifest.server_certificate_authority.manifest.spec.secretName
-        "clientCASecret"       = kubernetes_manifest.client_certificate_authority.manifest.spec.secretName
-        "replicationTLSSecret" = kubernetes_manifest.client_streaming_replica_certificate.manifest.spec.secretName
-      }
+      "certificates" = var.enable_internal_tls_certificates ? {
+        "serverTLSSecret"      = kubernetes_manifest.server_certificate[0].manifest.spec.secretName
+        "serverCASecret"       = kubernetes_manifest.server_certificate_authority[0].manifest.spec.secretName
+        "clientCASecret"       = kubernetes_manifest.client_certificate_authority[0].manifest.spec.secretName
+        "replicationTLSSecret" = kubernetes_manifest.client_streaming_replica_certificate[0].manifest.spec.secretName
+      } : null
       "plugins" = [
         {
           "name"          = "barman-cloud.cloudnative-pg.io"

--- a/modules/ferretdb/ferret.tf
+++ b/modules/ferretdb/ferret.tf
@@ -26,11 +26,11 @@ resource "kubernetes_deployment" "ferretdb" {
           "part-of" = "ferretdb"
         }
         
-        annotations = {
+        annotations = var.enable_observability ? {
           "prometheus.io/scrape" = "true"
           "prometheus.io/path"   = "/debug/metrics"
           "prometheus.io/port"   = "8088" 
-        }
+        } : {}
       }
 
       spec {

--- a/modules/ferretdb/ferret.tf
+++ b/modules/ferretdb/ferret.tf
@@ -88,10 +88,13 @@ resource "kubernetes_deployment" "ferretdb" {
           }
 
           // PostgreSQL Certificates
-          volume_mount {
-            name = "postgres-ca"
-            mount_path = "/etc/certs"
-            read_only = true
+          dynamic "volume_mount" {
+            for_each = var.enable_internal_tls_certificates ? [true] : []
+            content {
+              name = "postgres-ca"
+              mount_path = "/etc/certs"
+              read_only = true
+            }
           }
 
           env {
@@ -118,7 +121,7 @@ resource "kubernetes_deployment" "ferretdb" {
           }
           env {
             name = "FERRETDB_POSTGRESQL_URL"
-            value = "postgres://$(DB_USER):$(DB_PASS)@$(DB_HOST):5432/postgres?sslmode=verify-ca&sslrootcert=/etc/certs/ca.crt"
+            value = var.enable_internal_tls_certificates ? "postgres://$(DB_USER):$(DB_PASS)@$(DB_HOST):5432/postgres?sslmode=verify-ca&sslrootcert=/etc/certs/ca.crt" : "postgres://$(DB_USER):$(DB_PASS)@$(DB_HOST):5432/postgres"
           }
 
           readiness_probe {
@@ -143,13 +146,16 @@ resource "kubernetes_deployment" "ferretdb" {
           }
         }
 
-        volume {
-          name = "postgres-ca"
-          secret {
-            secret_name = kubernetes_manifest.server_certificate_authority.manifest.spec.secretName
-            items {
-              key = "ca.crt"
-              path = "ca.crt"
+        dynamic "volume" {
+          for_each = var.enable_internal_tls_certificates ? [true] : []
+          content {
+            name = "postgres-ca"
+            secret {
+              secret_name = kubernetes_manifest.server_certificate_authority[0].manifest.spec.secretName
+              items {
+                key = "ca.crt"
+                path = "ca.crt"
+              }
             }
           }
         }

--- a/modules/ferretdb/ferret.tf
+++ b/modules/ferretdb/ferret.tf
@@ -9,7 +9,7 @@ resource "kubernetes_deployment" "ferretdb" {
   }
 
   spec {
-    replicas = var.cluster_size
+    replicas = local.ferret_size_lookup[var.cluster_size]
     selector {
       match_labels = {
         app = var.app_name

--- a/modules/ferretdb/ingress.tf
+++ b/modules/ferretdb/ingress.tf
@@ -1,5 +1,6 @@
 // Kubernetes Ingress for Mongo Express Access
 resource "kubernetes_ingress_v1" "mongo_express_ingress" {
+  count = var.enable_ui ? 1 : 0
   metadata {
     name      = "mongo-express-ingress"
     namespace = kubernetes_namespace.namespace.metadata[0].name
@@ -9,10 +10,10 @@ resource "kubernetes_ingress_v1" "mongo_express_ingress" {
     }
     annotations = {
       "traefik.ingress.kubernetes.io/router.middlewares" = join(",", [
-        "${kubernetes_namespace.namespace.metadata[0].name}-${kubernetes_manifest.middleware_rewrite.manifest.metadata.name}@kubernetescrd",
-        "${kubernetes_namespace.namespace.metadata[0].name}-${kubernetes_manifest.middleware_buffering.manifest.metadata.name}@kubernetescrd"
+        "${kubernetes_namespace.namespace.metadata[0].name}-${kubernetes_manifest.middleware_rewrite[0].manifest.metadata.name}@kubernetescrd",
+        "${kubernetes_namespace.namespace.metadata[0].name}-${kubernetes_manifest.middleware_buffering[0].manifest.metadata.name}@kubernetescrd"
       ])
-      "traefik.ingress.kubernetes.io/service.serverstransport" = "${kubernetes_namespace.namespace.metadata[0].name}-${kubernetes_manifest.transport.manifest.metadata.name}@kubernetescrd"
+      "traefik.ingress.kubernetes.io/service.serverstransport" = "${kubernetes_namespace.namespace.metadata[0].name}-${kubernetes_manifest.transport[0].manifest.metadata.name}@kubernetescrd"
       "traefik.ingress.kubernetes.io/router.tls" = "true"
       "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
     }
@@ -22,7 +23,7 @@ resource "kubernetes_ingress_v1" "mongo_express_ingress" {
     ingress_class_name = "traefik"
     tls {
       hosts       = ["${var.host_name}.${var.domain}"]
-      secret_name = kubernetes_manifest.ingress_certificate.manifest.spec.secretName
+      secret_name = kubernetes_manifest.ingress_certificate[0].manifest.spec.secretName
     }
     rule {
       host = "${var.host_name}.${var.domain}"
@@ -31,7 +32,7 @@ resource "kubernetes_ingress_v1" "mongo_express_ingress" {
           path = "/"
           backend {
             service {
-              name = kubernetes_service.mongo_express.metadata[0].name
+              name = kubernetes_service.mongo_express[0].metadata[0].name
               port {
                 name = "https"
               }

--- a/modules/ferretdb/ingress.tf
+++ b/modules/ferretdb/ingress.tf
@@ -34,7 +34,7 @@ resource "kubernetes_ingress_v1" "mongo_express_ingress" {
             service {
               name = kubernetes_service.mongo_express[0].metadata[0].name
               port {
-                name = "https"
+                name = "ui"
               }
             }
           }

--- a/modules/ferretdb/locals.tf
+++ b/modules/ferretdb/locals.tf
@@ -16,4 +16,14 @@ locals {
     "replication" = false
     "superuser"   = false
   }]
+  cnpg_size_lookup = {
+    small  = 1
+    medium = 2
+    large  = 2
+  }
+  ferret_size_lookup = {
+    small  = 1
+    medium = 1
+    large  = 2
+  }
 }

--- a/modules/ferretdb/middleware.tf
+++ b/modules/ferretdb/middleware.tf
@@ -1,5 +1,6 @@
 // Middleware 1: The Rewrite logic
 resource "kubernetes_manifest" "middleware_rewrite" {
+  count = var.enable_ui ? 1 : 0
   manifest = {
     apiVersion = "traefik.io/v1alpha1"
     kind       = "Middleware"
@@ -18,6 +19,7 @@ resource "kubernetes_manifest" "middleware_rewrite" {
 
 // Middleware 2: The Buffering logic
 resource "kubernetes_manifest" "middleware_buffering" {
+  count = var.enable_ui ? 1 : 0
   manifest = {
     apiVersion = "traefik.io/v1alpha1"
     kind       = "Middleware"

--- a/modules/ferretdb/mongo-express.tf
+++ b/modules/ferretdb/mongo-express.tf
@@ -1,4 +1,5 @@
 resource "kubernetes_deployment" "mongo_express" {
+  count = var.enable_ui ? 1 : 0
   metadata {
     name = "mongo-express"
     namespace = kubernetes_namespace.namespace.metadata[0].name

--- a/modules/ferretdb/mongo-express.tf
+++ b/modules/ferretdb/mongo-express.tf
@@ -118,17 +118,23 @@ resource "kubernetes_deployment" "mongo_express" {
           // SSL Configuration for Mongo Express
           env {
             name = "ME_CONFIG_SITE_SSL_ENABLED"
-            value = "true"
+            value = var.enable_internal_tls_certificates ? "true" : "false"
           }
 
-          env {
-            name = "ME_CONFIG_SITE_SSL_CRT_PATH"
-            value = "/etc/mongoexpress/certs/tls.crt"
+          dynamic "env" {
+            for_each = var.enable_internal_tls_certificates ? [true] : []
+            content {
+              name = "ME_CONFIG_SITE_SSL_CRT_PATH"
+              value = "/etc/mongoexpress/certs/tls.crt"
+            }
           }
-          
-          env {
-            name = "ME_CONFIG_SITE_SSL_KEY_PATH"
-            value = "/etc/mongoexpress/certs/tls.key"
+
+          dynamic "env" {
+            for_each = var.enable_internal_tls_certificates ? [true] : []
+            content {
+              name = "ME_CONFIG_SITE_SSL_KEY_PATH"
+              value = "/etc/mongoexpress/certs/tls.key"
+            }
           }
 
           port {
@@ -171,17 +177,23 @@ resource "kubernetes_deployment" "mongo_express" {
             failure_threshold = 5
           }
 
-          volume_mount {
-            name = "tls-certs"
-            mount_path = "/etc/mongoexpress/certs"
-            read_only = true
+          dynamic "volume_mount" {
+            for_each = var.enable_internal_tls_certificates ? [true] : []
+            content {
+              name = "tls-certs"
+              mount_path = "/etc/mongoexpress/certs"
+              read_only = true
+            }
           }
         }
 
-        volume {
-          name = "tls-certs"
-          secret {
-            secret_name = kubernetes_manifest.mongo_express_internal_certificate.manifest.spec.secretName
+        dynamic "volume" {
+          for_each = var.enable_internal_tls_certificates ? [true] : []
+          content {
+            name = "tls-certs"
+            secret {
+              secret_name = kubernetes_manifest.mongo_express_internal_certificate[0].manifest.spec.secretName
+            }
           }
         }
       }

--- a/modules/ferretdb/mongo-express.tf
+++ b/modules/ferretdb/mongo-express.tf
@@ -158,7 +158,7 @@ resource "kubernetes_deployment" "mongo_express" {
             http_get {
               path = "/status"
               port = 8081
-              scheme = "HTTPS"
+              scheme = var.enable_internal_tls_certificates ? "HTTPS" : "HTTP"
             }
             initial_delay_seconds = 10
             period_seconds = 10
@@ -170,7 +170,7 @@ resource "kubernetes_deployment" "mongo_express" {
             http_get {
               path = "/status"
               port = 8081
-              scheme = "HTTPS"
+              scheme = var.enable_internal_tls_certificates ? "HTTPS" : "HTTP"
             }
             initial_delay_seconds = 10
             period_seconds = 10

--- a/modules/ferretdb/networkpolicy.tf
+++ b/modules/ferretdb/networkpolicy.tf
@@ -71,7 +71,7 @@ resource "kubernetes_network_policy" "cnpg_network_policy" {
           match_expressions {
             key      = "kubernetes.io/metadata.name"
             operator = "In"
-            values   = concat(local.access_namespaces, ["keycloak", kubernetes_namespace.namespace.metadata[0].name])
+            values   = concat(local.access_namespaces, [kubernetes_namespace.namespace.metadata[0].name])
           }
         }
 
@@ -89,24 +89,27 @@ resource "kubernetes_network_policy" "cnpg_network_policy" {
     }
 
     # Rule 4: Allow OpenTelemetry Collector to scrape CNPG metrics
-    ingress {
-      from {
-        namespace_selector {
-          match_labels = {
-            "kubernetes.io/metadata.name" = var.observability_namespace
+    dynamic "ingress" {
+      for_each = var.enable_observability ? [true] : []
+      content {
+        from {
+          namespace_selector {
+            match_labels = {
+              "kubernetes.io/metadata.name" = var.observability_namespace
+            }
+          }
+
+          pod_selector {
+            match_labels = {
+              "app.kubernetes.io/instance" = "otel-collector"
+            }
           }
         }
 
-        pod_selector {
-          match_labels = {
-            "app.kubernetes.io/instance" = "otel-collector" 
-          }
+        ports {
+          protocol = "TCP"
+          port     = 9187
         }
-      }
-
-      ports {
-        protocol = "TCP"
-        port     = 9187
       }
     }
 
@@ -136,18 +139,21 @@ resource "kubernetes_network_policy" "cnpg_network_policy" {
     }
 
     # Rule 2: Allow egress to Garage S3 Cluster for PITR
-    egress {
-      to {
-        namespace_selector {
-          match_labels = {
-            "kubernetes.io/metadata.name" = var.garage_namespace
+    dynamic "egress" {
+      for_each = var.enable_pitr_backups ? [true] : []
+      content {
+        to {
+          namespace_selector {
+            match_labels = {
+              "kubernetes.io/metadata.name" = var.garage_namespace
+            }
           }
         }
-      }
 
-      ports {
-        protocol = "TCP"
-        port     = 3940
+        ports {
+          protocol = "TCP"
+          port     = 3940
+        }
       }
     }
 
@@ -235,24 +241,27 @@ resource "kubernetes_network_policy" "ferret_network_policy" {
     }
     
     # Rule 2: Allow OpenTelemetry Collector to scrape FerretDB metrics
-    ingress {
-      from {
-        namespace_selector {
-          match_labels = {
-            "kubernetes.io/metadata.name" = var.observability_namespace
+    dynamic "ingress" {
+      for_each = var.enable_observability ? [true] : []
+      content {
+        from {
+          namespace_selector {
+            match_labels = {
+              "kubernetes.io/metadata.name" = var.observability_namespace
+            }
+          }
+
+          pod_selector {
+            match_labels = {
+              "app.kubernetes.io/instance" = "otel-collector"
+            }
           }
         }
 
-        pod_selector {
-          match_labels = {
-            "app.kubernetes.io/instance" = "otel-collector" 
-          }
+        ports {
+          protocol = "TCP"
+          port     = 8088
         }
-      }
-
-      ports {
-        protocol = "TCP"
-        port     = 8088
       }
     }
 

--- a/modules/ferretdb/objectstore.tf
+++ b/modules/ferretdb/objectstore.tf
@@ -1,4 +1,5 @@
 resource "kubernetes_manifest" "barman_object_store" {
+  count = var.enable_pitr_backups ? 1 : 0
   manifest = {
     "apiVersion" = "barmancloud.cnpg.io/v1"
     "kind"       = "ObjectStore"
@@ -22,21 +23,21 @@ resource "kubernetes_manifest" "barman_object_store" {
         "destinationPath" = "s3://${var.backup_bucket_name}/"
         "endpointCA" = {
           "key"  = "ca.crt"
-          "name" = kubernetes_manifest.garage_certificate_authority_sync.object.metadata.name
+          "name" = kubernetes_manifest.garage_certificate_authority_sync[0].object.metadata.name
         }
         "endpointURL" = "https://garage-service.${var.garage_namespace}.svc.cluster.local:3940"
         "s3Credentials" = {
           "accessKeyId" = {
             "key"  = "ACCESS_KEY_ID"
-            "name" = kubernetes_manifest.garage_configuration_sync.object.metadata.name
+            "name" = kubernetes_manifest.garage_configuration_sync[0].object.metadata.name
           }
           "secretAccessKey" = {
             "key"  = "SECRET_ACCESS_KEY"
-            "name" = kubernetes_manifest.garage_configuration_sync.object.metadata.name
+            "name" = kubernetes_manifest.garage_configuration_sync[0].object.metadata.name
           }
           "region" = {
             "key"  = "S3_REGION"
-            "name" = kubernetes_manifest.garage_configuration_sync.object.metadata.name
+            "name" = kubernetes_manifest.garage_configuration_sync[0].object.metadata.name
           }
         }
         "wal" = {

--- a/modules/ferretdb/secrets.tf
+++ b/modules/ferretdb/secrets.tf
@@ -1,5 +1,6 @@
 // Garage Credentials for storing PostgreSQL PITR Backups
 resource "kubernetes_manifest" "garage_configuration_sync" {
+  count = var.enable_pitr_backups ? 1 : 0
   manifest = {
     apiVersion = "external-secrets.io/v1"
     kind       = "ExternalSecret"

--- a/modules/ferretdb/service.tf
+++ b/modules/ferretdb/service.tf
@@ -44,7 +44,7 @@ resource "kubernetes_service" "mongo_express" {
     port {
       port        = 8081
       target_port = 8081
-      name        = "https"
+      name        = "ui"
     }
 
     selector = {

--- a/modules/ferretdb/service.tf
+++ b/modules/ferretdb/service.tf
@@ -28,6 +28,7 @@ resource "kubernetes_service" "ferret_service" {
 
 // Mongo Express Service for Ingress Usage
 resource "kubernetes_service" "mongo_express" {
+  count = var.enable_ui ? 1 : 0
   metadata {
     name      = "mongo-express-service"
     namespace = kubernetes_namespace.namespace.metadata[0].name

--- a/modules/ferretdb/transport.tf
+++ b/modules/ferretdb/transport.tf
@@ -1,5 +1,6 @@
 // Server Transport Resource for HTTPS Backend Connections
 resource "kubernetes_manifest" "transport" {
+  count = var.enable_ui ? 1 : 0
   manifest = {
     apiVersion = "traefik.io/v1alpha1"
     kind       = "ServersTransport"

--- a/modules/ferretdb/transport.tf
+++ b/modules/ferretdb/transport.tf
@@ -10,11 +10,11 @@ resource "kubernetes_manifest" "transport" {
     }
     spec = {
       insecureSkipVerify = true
-      rootCAs = [
+      rootCAs = var.enable_internal_tls_certificates ? [
         {
-          secret = var.enable_internal_tls_certificates ? kubernetes_manifest.mongo_express_internal_certificate[0].manifest.spec.secretName : null
+          secret = kubernetes_manifest.mongo_express_internal_certificate[0].manifest.spec.secretName
         }
-      ]
+      ] : []
     }
   }
 }

--- a/modules/ferretdb/transport.tf
+++ b/modules/ferretdb/transport.tf
@@ -11,7 +11,7 @@ resource "kubernetes_manifest" "transport" {
       insecureSkipVerify = true
       rootCAs = [
         {
-          secret = kubernetes_manifest.mongo_express_internal_certificate.manifest.spec.secretName
+          secret = var.enable_internal_tls_certificates ? kubernetes_manifest.mongo_express_internal_certificate[0].manifest.spec.secretName : null
         }
       ]
     }

--- a/modules/ferretdb/variables.tf
+++ b/modules/ferretdb/variables.tf
@@ -229,3 +229,28 @@ variable "kubernetes_api_port" {
   type        = number
   nullable    = false
 }
+
+# --------------- DEPLOYMENT CUSTOMIZATION VARIABLES --------------- #
+variable "enable_internal_tls_certificates" {
+  description = "Enable or disable deployment of Internal TLS Certificates for the FerretDB Cluster"
+  type        = bool
+  default     = true
+}
+
+variable "enable_ui" {
+  description = "Enable or disable deployment of PGAdmin for the FerretDB Cluster"
+  type        = bool
+  default     = true
+}
+
+variable "enable_pitr_backups" {
+  description = "Enable or disable PITR Backups to the Garage Instance for the FerretDB Cluster"
+  type        = bool
+  default     = true
+}
+
+variable "enable_observability" {
+  description = "Enable or disable observability reporting for the FerretDB Cluster"
+  type        = bool
+  default     = true
+}

--- a/modules/ferretdb/variables.tf
+++ b/modules/ferretdb/variables.tf
@@ -163,9 +163,14 @@ variable "cluster_postgresql_version" {
 }
 
 variable "cluster_size" {
-  description = "Number of pods to deploy for the Ferret Cluster"
-  type        = number
-  default     = 2
+  description = "Number of pods to deploy for the PostgreSQL Cluster"
+  type        = string
+  default     = "small"
+
+  validation {
+    condition     = contains(["small", "medium", "large"], var.cluster_size)
+    error_message = "Valid values for variable size are small, medium and large"
+  }
 }
 
 variable "backup_bucket_name" {


### PR DESCRIPTION
# Implemented Changes
- The following feature flags are now provided and supported:
     - Enable or Disable Internal TLS Certificates
     - Enable or Disable Deployment of UI Component
     - Enable or Disable PITR Backups
     - Enable or Disable Observability
- The following scaling options are now provided and supported:
     - Small: `2 pod` (no read replicas, 1 FerretDB Pod)
     - Medium: `3 pods` (1 read replica, 1 FerretDB Pod)
     - Large: `4 pods` (1 read replica, 2 FerretDB Pods)

**Closes: #158**
