### PR TITLE
[BUG] Ingress-Exposed Annotations Update to reflect Internal TLS Configuration

### DIFF
--- a/modules/cnpg/service.tf
+++ b/modules/cnpg/service.tf
@@ -8,6 +8,9 @@ resource "kubernetes_service" "pgadmin4" {
       app       = var.app_name
       component = "service"
     }
+    annotations = {
+      "traefik.ingress.kubernetes.io/service.serversscheme" = var.enable_internal_tls_certificates ? "https" : "http"
+    }
   }
 
   spec {

--- a/modules/ferretdb/service.tf
+++ b/modules/ferretdb/service.tf
@@ -36,6 +36,9 @@ resource "kubernetes_service" "mongo_express" {
       app       = var.app_name
       component = "service"
     }
+    annotations = {
+      "traefik.ingress.kubernetes.io/service.serversscheme" = var.enable_internal_tls_certificates ? "https" : "http"
+    }
   }
 
   spec {

--- a/modules/garage/service.tf
+++ b/modules/garage/service.tf
@@ -37,7 +37,7 @@ resource "kubernetes_service" "garage-service" {
       component = "service"
     }
     annotations = {
-      "traefik.ingress.kubernetes.io/service.serversscheme" = "https"
+      "traefik.ingress.kubernetes.io/service.serversscheme" = var.enable_internal_tls_certificates ? "https" : "http"
     }
   }
 

--- a/modules/keycloak/service.tf
+++ b/modules/keycloak/service.tf
@@ -26,6 +26,9 @@ resource "kubernetes_service" "keycloak_service" {
   metadata {
     name      = "keycloak-cluster-service"
     namespace = kubernetes_namespace.namespace.metadata[0].name
+    annotations = {
+      "traefik.ingress.kubernetes.io/service.serversscheme" = var.enable_internal_tls_certificates ? "https" : "http"
+    }
   }
 
   spec {

--- a/modules/openbao/openbao.tf
+++ b/modules/openbao/openbao.tf
@@ -121,6 +121,13 @@ resource "helm_release" "openbao" {
           enabled = true
         }
 
+        // Annotations to the Service Object
+        service = {
+          annotations = {
+            "traefik.ingress.kubernetes.io/service.serversscheme" = var.enable_internal_tls_certificates ? "https" : "http"
+          }
+        }
+
         // Enable permissions for
         // Service Discovery
         serviceAccount = {

--- a/modules/valkey/service.tf
+++ b/modules/valkey/service.tf
@@ -88,7 +88,7 @@ resource "kubernetes_service" "ui_service" {
       component = "service"
     }
     annotations = {
-      "traefik.ingress.kubernetes.io/service.serversscheme" = "https"
+      "traefik.ingress.kubernetes.io/service.serversscheme" = var.enable_internal_tls_certificates ? "https" : "http"
     }
   }
 

--- a/modules/valkey/statefulset.tf
+++ b/modules/valkey/statefulset.tf
@@ -170,7 +170,7 @@ resource "kubernetes_stateful_set" "valkey_cluster" {
             // Valkey Connection String
             env {
               name  = "REDIS_ADDR"
-              value = "rediss://localhost:6379"
+              value = var.enable_internal_tls_certificates ? "rediss://localhost:6379" : "redis://localhost:6379"
             }
 
             // Password Authentication for the cluster


### PR DESCRIPTION
# Proposed Fixes
  - Reported in #170, issue was observed in Valkey so fixed the service annotations for that module
  - Additionally, propagated the same change across all modules with the Internal TLS Certificate feature switch support

**Closes: #170**
